### PR TITLE
Event Tracking

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,3 +8,5 @@ var EVENT_DB_HOST = os.Getenv("EVENT_DB_HOST")
 var EVENT_DB_NAME = os.Getenv("EVENT_DB_NAME")
 
 var EVENT_PORT = os.Getenv("EVENT_PORT")
+
+var CHECKIN_SERVICE = os.Getenv("CHECKIN_SERVICE")

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -17,9 +17,9 @@ func SetupController(route *mux.Route) {
 	router.Handle("/", alice.New().ThenFunc(CreateEvent)).Methods("POST")
 	router.Handle("/", alice.New().ThenFunc(UpdateEvent)).Methods("PUT")
 
-	router.Handle("/event/track/", alice.New().ThenFunc(MarkUserAsAttendingEvent)).Methods("POST")
-	router.Handle("/event/track/event/{name}/", alice.New().ThenFunc(GetEventTrackingInfo)).Methods("GET")
-	router.Handle("/event/track/user/{id}/", alice.New().ThenFunc(GetUserTrackingInfo)).Methods("GET")
+	router.Handle("/track/", alice.New().ThenFunc(MarkUserAsAttendingEvent)).Methods("POST")
+	router.Handle("/track/event/{name}/", alice.New().ThenFunc(GetEventTrackingInfo)).Methods("GET")
+	router.Handle("/track/user/{id}/", alice.New().ThenFunc(GetUserTrackingInfo)).Methods("GET")
 }
 
 /*

--- a/docs/Event.md
+++ b/docs/Event.md
@@ -90,3 +90,64 @@ Response format:
 	"eventType": "WORKSHOP"
 }
 ```
+
+POST /event/track/
+------------------
+
+Marks the specified user as attending the specified event. Returns the tracker for the user and the tracker for the event.
+
+Request format:
+```
+{
+	"eventName": "Example Event",
+	"userId": "github0000001"
+}
+```
+
+Response format:
+```
+{
+	"eventTracker": {
+		"eventName": "Example Event",
+		"users": [
+			"github0000001",
+		]
+	},
+	"userTracker": {
+		"userId": "github0000001",
+		"events": [
+			"Example Event"
+		]
+	}
+}
+```
+
+GET /event/track/event/EVENTNAME/
+---------------------------------
+
+Returns the tracker for the event with the name `EVENTNAME`.
+
+Response format:
+```
+{
+	"eventName": "Example Event",
+	"users": [
+		"github0000001",
+	]
+}
+```
+
+GET /event/track/user/USERID/
+-----------------------------
+
+Returns the tracker for the user with the id `USERID`.
+
+Response format:
+```
+{
+	"userId": "github0000001",
+	"events": [
+		"Example Event"
+	]
+}
+```

--- a/models/event_tracker.go
+++ b/models/event_tracker.go
@@ -1,0 +1,6 @@
+package models
+
+type EventTracker struct {
+	EventName string   `json:"eventName"`
+	Users     []string `json:"users"`
+}

--- a/models/tracking_info.go
+++ b/models/tracking_info.go
@@ -1,0 +1,6 @@
+package models
+
+type TrackingInfo struct {
+	EventName string `json:"eventName"`
+	UserID    string `json:"userId"`
+}

--- a/models/tracking_status.go
+++ b/models/tracking_status.go
@@ -1,0 +1,6 @@
+package models
+
+type TrackingStatus struct {
+	EventTracker EventTracker `json:"eventTracker"`
+	UserTracker  UserTracker  `json:"userTracker"`
+}

--- a/models/user_tracker.go
+++ b/models/user_tracker.go
@@ -1,6 +1,6 @@
 package models
 
 type UserTracker struct {
-	ID     string   `json:"id"`
+	UserID string   `json:"userId"`
 	Events []string `json:"events"`
 }

--- a/models/user_tracker.go
+++ b/models/user_tracker.go
@@ -1,0 +1,6 @@
+package models
+
+type UserTracker struct {
+	ID     string   `json:"id"`
+	Events []string `json:"events"`
+}

--- a/service/checkin_service.go
+++ b/service/checkin_service.go
@@ -1,0 +1,19 @@
+package service
+
+import (
+	"github.com/HackIllinois/api-event/config"
+	"net/http"
+)
+
+/*
+	Checks if the user has been checked in with the checkin service
+*/
+func IsUserCheckedIn(id string) (bool, error) {
+	resp, err := http.Get(config.CHECKIN_SERVICE + "/checkin/" + id + "/")
+
+	if err != nil {
+		return false, err
+	}
+
+	return resp.StatusCode == http.StatusOK, nil
+}

--- a/service/event_service.go
+++ b/service/event_service.go
@@ -67,6 +67,17 @@ func CreateEvent(name string, event models.Event) error {
 
 	err = db.Insert("events", &event)
 
+	if err != nil {
+		return err
+	}
+
+	event_tracker := models.EventTracker{
+		EventName: name,
+		Users:     []string{},
+	}
+
+	err = db.Insert("eventtrackers", &event_tracker)
+
 	return err
 }
 

--- a/service/event_service.go
+++ b/service/event_service.go
@@ -130,6 +130,12 @@ func GetUserTracker(user_id string) (*models.UserTracker, error) {
 	err := db.FindOne("usertrackers", query, &tracker)
 
 	if err != nil {
+		if err == mgo.ErrNotFound {
+			return &models.UserTracker{
+				UserID: user_id,
+				Events: []string{},
+			}, nil
+		}
 		return nil, err
 	}
 

--- a/service/event_service.go
+++ b/service/event_service.go
@@ -99,3 +99,116 @@ func UpdateEvent(name string, event models.Event) error {
 
 	return err
 }
+
+/*
+	Returns the event tracker for the specified event
+*/
+func GetEventTracker(event_name string) (*models.EventTracker, error) {
+	query := bson.M{
+		"eventname": event_name,
+	}
+
+	var tracker models.EventTracker
+	err := db.FindOne("eventtrackers", query, &tracker)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &tracker, nil
+}
+
+/*
+	Returns the user tracker for the specified user
+*/
+func GetUserTracker(user_id string) (*models.UserTracker, error) {
+	query := bson.M{
+		"userId": user_id,
+	}
+
+	var tracker models.UserTracker
+	err := db.FindOne("usertrackers", query, &tracker)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &tracker, nil
+}
+
+/*
+	Returns true is the user has already been marked as attending
+	the specified event, false otherwise
+*/
+func IsUserAttendingEvent(event_name string, user_id string) (bool, error) {
+	tracker, err := GetEventTracker(event_name)
+
+	if err != nil {
+		return false, err
+	}
+
+	for _, id := range tracker.Users {
+		if user_id == id {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+/*
+	Marks the specified user as attending the specified event
+	The user must be checkedin and not already marked as attending
+	for this to return successfully
+*/
+func MarkUserAsAttendingEvent(event_name string, user_id string) error {
+	is_attending, err := IsUserAttendingEvent(event_name, user_id)
+
+	if err != nil {
+		return err
+	}
+
+	if is_attending {
+		return errors.New("User has already been marked as attending")
+	}
+
+	is_checkedin, err := IsUserCheckedIn(user_id)
+
+	if err != nil {
+		return err
+	}
+
+	if !is_checkedin {
+		return errors.New("User must be checked in to attend event")
+	}
+
+	event_selector := bson.M{
+		"eventname": event_name,
+	}
+
+	event_modifier := bson.M{
+		"$addToSet": bson.M{
+			"users": user_id,
+		},
+	}
+
+	err = db.Update("eventtrackers", event_selector, &event_modifier)
+
+	if err != nil {
+		return err
+	}
+
+	user_selector := bson.M{
+		"userid": user_id,
+	}
+
+	user_modifier := bson.M{
+		"$addToSet": bson.M{
+			"events": event_name,
+		},
+	}
+
+	err = db.Update("usertrackers", user_selector, &user_modifier)
+
+	return err
+}

--- a/tests/event_test.go
+++ b/tests/event_test.go
@@ -242,3 +242,55 @@ func TestMarkUserAsAttendingEventService(t *testing.T) {
 
 	CleanupTestDB(t)
 }
+
+/*
+	Service level test for marking a user as attending an event
+	when they have already been marked as attending
+*/
+func TestMarkUserAsAttendingEventErrorService(t *testing.T) {
+	SetupTestDB(t)
+
+	err := service.MarkUserAsAttendingEvent("testname", "testuser")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = service.MarkUserAsAttendingEvent("testname", "testuser")
+
+	if err == nil {
+		t.Fatal("User was marked as attending event twice")
+	}
+
+	event_tracker, err := service.GetEventTracker("testname")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_event_tracker := models.EventTracker{
+		EventName: "testname",
+		Users:     []string{"testuser"},
+	}
+
+	if !reflect.DeepEqual(event_tracker, &expected_event_tracker) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", expected_event_tracker, event_tracker)
+	}
+
+	user_tracker, err := service.GetUserTracker("testuser")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_user_tracker := models.UserTracker{
+		UserID: "testuser",
+		Events: []string{"testname"},
+	}
+
+	if !reflect.DeepEqual(user_tracker, &expected_user_tracker) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", expected_user_tracker, user_tracker)
+	}
+
+	CleanupTestDB(t)
+}

--- a/tests/event_test.go
+++ b/tests/event_test.go
@@ -42,6 +42,17 @@ func SetupTestDB(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	event_tracker := models.EventTracker{
+		EventName: "testname",
+		Users:     []string{},
+	}
+
+	err = db.Insert("eventtrackers", &event_tracker)
+
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 /*
@@ -182,6 +193,51 @@ func TestUpdateEventService(t *testing.T) {
 
 	if !reflect.DeepEqual(updated_event, &expected_event) {
 		t.Errorf("Wrong user info. Expected %v, got %v", expected_event, updated_event)
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
+	Service level test for marking a user as attending an event
+*/
+func TestMarkUserAsAttendingEventService(t *testing.T) {
+	SetupTestDB(t)
+
+	err := service.MarkUserAsAttendingEvent("testname", "testuser")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	event_tracker, err := service.GetEventTracker("testname")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_event_tracker := models.EventTracker{
+		EventName: "testname",
+		Users:     []string{"testuser"},
+	}
+
+	if !reflect.DeepEqual(event_tracker, &expected_event_tracker) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", expected_event_tracker, event_tracker)
+	}
+
+	user_tracker, err := service.GetUserTracker("testuser")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_user_tracker := models.UserTracker{
+		UserID: "testuser",
+		Events: []string{"testname"},
+	}
+
+	if !reflect.DeepEqual(user_tracker, &expected_user_tracker) {
+		t.Errorf("Wrong tracker info. Expected %v, got %v", expected_user_tracker, user_tracker)
 	}
 
 	CleanupTestDB(t)


### PR DESCRIPTION
Addresses #2 

- [x] Added `POST /event/track/` to mark users as attending an event
    - [x] Users must be checked in and can only be marked as attending once
- [x] Added `GET /event/track/event/{name}/ to get the users marked as attending for a specified event
- [x] Added `GET /event/track/user/{id}/` to get the events that a specified user was marked as attending

All operations which modify the database are done atomically to allow many users to be marked as attending at once on concurrent requests.