### PR TITLE
Added endpoint to get all events

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -16,6 +16,7 @@ func SetupController(route *mux.Route) {
 	router.Handle("/{name}/", alice.New().ThenFunc(GetEvent)).Methods("GET")
 	router.Handle("/", alice.New().ThenFunc(CreateEvent)).Methods("POST")
 	router.Handle("/", alice.New().ThenFunc(UpdateEvent)).Methods("PUT")
+	router.Handle("/", alice.New().ThenFunc(GetAllEvents)).Methods("GET")
 
 	router.Handle("/track/", alice.New().ThenFunc(MarkUserAsAttendingEvent)).Methods("POST")
 	router.Handle("/track/event/{name}/", alice.New().ThenFunc(GetEventTrackingInfo)).Methods("GET")
@@ -35,6 +36,19 @@ func GetEvent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	json.NewEncoder(w).Encode(event)
+}
+
+/*
+	Endpoint to get all events
+*/
+func GetAllEvents(w http.ResponseWriter, r *http.Request) {
+	event_list, err := service.GetAllEvents()
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(event_list)
 }
 
 /*

--- a/docs/Event.md
+++ b/docs/Event.md
@@ -21,6 +21,41 @@ Response format:
 }
 ```
 
+GET /event/
+---------------------
+
+Returns a list of all events.
+
+Response format:
+```
+{
+	events: [
+		{
+			"name": "Example Event",
+			"description": "This is a description",
+			"startTime": 1532202702,
+			"endTime": 1532212702,
+			"locationDescription": "Example Location",
+			"latitude": 40.1138,
+			"longitude": -88.2249,
+			"sponsor": "Example sponsor",
+			"eventType": "WORKSHOP"
+		},
+		{
+			"name": "Example Event 2",
+			"description": "This is another description",
+			"startTime": 1532202703,
+			"endTime": 1532212703,
+			"locationDescription": "Example Location 2",
+			"latitude": 40.1139,
+			"longitude": -88.2250,
+			"sponsor": "Example sponsor 2",
+			"eventType": "WORKSHOP"
+		}
+	]
+}
+```
+
 POST /event/
 -----------
 

--- a/models/event_list.go
+++ b/models/event_list.go
@@ -1,0 +1,5 @@
+package models
+
+type EventList struct {
+	Events []Event `json:"events"`
+}

--- a/service/event_service.go
+++ b/service/event_service.go
@@ -47,6 +47,25 @@ func GetEvent(name string) (*models.Event, error) {
 }
 
 /*
+	Returns all the events
+*/
+func GetAllEvents() (*models.EventList, error) {
+	var events []models.Event
+	// nil implies there are no filters on the query, therefore everything in the "events" collection is returned.
+	err := db.FindAll("events", nil, &events)
+
+	if err != nil {
+		return nil, err
+	}
+
+	event_list := models.EventList{
+		Events: events,
+	}
+
+	return &event_list, nil
+}
+
+/*
 	Creates an event with the given name
 */
 func CreateEvent(name string, event models.Event) error {

--- a/tests/event_test.go
+++ b/tests/event_test.go
@@ -70,6 +70,67 @@ func CleanupTestDB(t *testing.T) {
 }
 
 /*
+	Service level test for getting all events from db
+*/
+func TestGetAllEventsService(t *testing.T) {
+	SetupTestDB(t)
+
+	event := models.Event{
+		Name:                "testname2",
+		Description:         "testdescription2",
+		StartTime:           1000,
+		EndTime:             2000,
+		LocationDescription: "testlocationdescription",
+		Latitude:            123.456,
+		Longitude:           123.456,
+		Sponsor:             "testsponsor",
+		EventType:           "WORKSHOP",
+	}
+
+	err := db.Insert("events", &event)
+
+	actual_event_list, err := service.GetAllEvents()
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected_event_list := models.EventList{
+		Events: []models.Event{
+			models.Event{
+				Name:                "testname",
+				Description:         "testdescription",
+				StartTime:           1000,
+				EndTime:             2000,
+				LocationDescription: "testlocationdescription",
+				Latitude:            123.456,
+				Longitude:           123.456,
+				Sponsor:             "testsponsor",
+				EventType:           "WORKSHOP",
+			},
+			models.Event{
+				Name:                "testname2",
+				Description:         "testdescription2",
+				StartTime:           1000,
+				EndTime:             2000,
+				LocationDescription: "testlocationdescription",
+				Latitude:            123.456,
+				Longitude:           123.456,
+				Sponsor:             "testsponsor",
+				EventType:           "WORKSHOP",
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(actual_event_list, &expected_event_list) {
+		t.Errorf("Wrong event list. Expected %v, got %v", expected_event_list, actual_event_list)
+	}
+
+	CleanupTestDB(t)
+
+}
+
+/*
 	Service level test for getting event from db
 */
 func TestGetEventService(t *testing.T) {


### PR DESCRIPTION
Addresses #10 


- [x] Added `GET /event/` to retrieve all events

Response body:

```json

{
    "events": [
        {
            "description": "This is a description",
            "endTime": 1532212702,
            "eventType": "WORKSHOP",
            "latitude": 40.1138,
            "locationDescription": "Example Location",
            "longitude": -88.2249,
            "name": "Example Event",
            "sponsor": "Example sponsor",
            "startTime": 1532202702
        },
        {
            "description": "This is a description 2",
            "endTime": 1532212702,
            "eventType": "WORKSHOP",
            "latitude": 40.1138,
            "locationDescription": "Example Location",
            "longitude": -88.2249,
            "name": "Example Event 2",
            "sponsor": "Example sponsor",
            "startTime": 1532202702
        },
        {
            "description": "This is a description 3",
            "endTime": 1532212702,
            "eventType": "WORKSHOP",
            "latitude": 40.1138,
            "locationDescription": "Example Location",
            "longitude": -88.2249,
            "name": "Example Event 3",
            "sponsor": "Example sponsor",
            "startTime": 1532202702
        }
    ]
}```
