### PR TITLE
Added delete event endpoint

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -14,6 +14,7 @@ func SetupController(route *mux.Route) {
 	router := route.Subrouter()
 
 	router.Handle("/{name}/", alice.New().ThenFunc(GetEvent)).Methods("GET")
+	router.Handle("/{name}/", alice.New().ThenFunc(DeleteEvent)).Methods("DELETE")
 	router.Handle("/", alice.New().ThenFunc(CreateEvent)).Methods("POST")
 	router.Handle("/", alice.New().ThenFunc(UpdateEvent)).Methods("PUT")
 
@@ -29,6 +30,23 @@ func GetEvent(w http.ResponseWriter, r *http.Request) {
 	name := mux.Vars(r)["name"]
 
 	event, err := service.GetEvent(name)
+
+	if err != nil {
+		panic(errors.UnprocessableError(err.Error()))
+	}
+
+	json.NewEncoder(w).Encode(event)
+}
+
+/*
+	Endpoint to delete an event with the specified name.
+	It removes the event from the event trackers, and every user's tracker.
+	On successful deletion, it returns the event that was deleted.
+*/
+func DeleteEvent(w http.ResponseWriter, r *http.Request) {
+	name := mux.Vars(r)["name"]
+
+	event, err := service.DeleteEvent(name)
 
 	if err != nil {
 		panic(errors.UnprocessableError(err.Error()))

--- a/docs/Event.md
+++ b/docs/Event.md
@@ -56,7 +56,7 @@ Response format:
 }
 ```
 
-DELETE /event/EVENTNAME
+DELETE /event/EVENTNAME/
 -----------
 
 Endpoint to delete an event with name `EVENTNAME`. `EVENTNAME` should be url encoded.

--- a/docs/Event.md
+++ b/docs/Event.md
@@ -56,6 +56,27 @@ Response format:
 }
 ```
 
+DELETE /event/EVENTNAME
+-----------
+
+Endpoint to delete an event with name `EVENTNAME`. `EVENTNAME` should be url encoded.
+It removes the `EVENTNAME` from the event trackers, and every user's tracker.
+
+Response format:
+```
+{
+	"name": "Example Event",
+	"description": "This is a description",
+	"startTime": 1532202702,
+	"endTime": 1532212702,
+	"locationDescription": "Example Location",
+	"latitude": 40.1138,
+	"longitude": -88.2249,
+	"sponsor": "Example sponsor",
+	"eventType": "WORKSHOP"
+}
+```
+
 PUT /event/
 ----------
 

--- a/tests/event_test.go
+++ b/tests/event_test.go
@@ -150,6 +150,71 @@ func TestCreateEventService(t *testing.T) {
 }
 
 /*
+	Service level test for deleting an event in the db
+*/
+func TestDeleteEventService(t *testing.T) {
+	SetupTestDB(t)
+
+	event_name := "testname"
+
+	// Mark 3 users as attending the event
+
+	err := service.MarkUserAsAttendingEvent(event_name, "user0")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = service.MarkUserAsAttendingEvent(event_name, "user1")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = service.MarkUserAsAttendingEvent(event_name, "user2")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to delete the event
+
+	_, err = service.DeleteEvent(event_name)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Try to find the event in the events db
+	event, err := service.GetEvent(event_name)
+
+	if err == nil {
+		t.Errorf("Found event %v in events database.", event)
+	}
+
+	// Try to find the event in the eventtrackers db
+	event_tracker, err := service.GetEventTracker(event_name)
+
+	if err == nil {
+		t.Errorf("Found event in the eventtracker %v.", event_tracker)
+	}
+
+	// Try to find the event in the usertrackers db
+	var user_trackers []models.UserTracker
+	db.FindAll("usertrackers", nil, &user_trackers)
+
+	for _, user_tracker := range user_trackers {
+		for _, event := range user_tracker.Events {
+			if event == event_name {
+				t.Errorf("Found event in the usertracker %v.", user_tracker)
+			}
+		}
+	}
+
+	CleanupTestDB(t)
+}
+
+/*
 	Service level test for updating an event in the db
 */
 func TestUpdateEventService(t *testing.T) {


### PR DESCRIPTION
Addresses #1 
- Endpoint to delete an event with the specified name.
- It removes the event from the event trackers, and every user's tracker.
- On successful deletion, it returns the event that was deleted.